### PR TITLE
Fixed compiler errors with version 1.58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-piston_window = "0.108.0"
-ggez = "0.5.1"
-rand = "0.7.3" 
+ggez = "0.7.0"
+glam = "0.20.2"
+rand = "0.8.5"


### PR DESCRIPTION
- updated calls to `ggez` to match the newest version
- moved from `nalgebra` to `glam` for vector and matrix manipulations
- updated crates in `Cargo.toml`

Fixes isendaniel/boids#1.